### PR TITLE
Increase participation deadline

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -46,7 +46,7 @@ class Challenge < ActiveRecord::Base
   end
 
   def participation_deadline
-    deadline - 5.hours
+    deadline - 8.hours
   end
 
   private


### PR DESCRIPTION
It was previously reduced from 10 hours to 5, but 5 is way to little.
It should be safe to go to bed knowing that no more people will be attending when you wake up.